### PR TITLE
house all shared fs files under a base shared directory

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -13,9 +13,9 @@ func GetOrDefaultEnv(key string, fallback string) string {
 const WEIGHTS_FILENAME = "weights.h5"     // must be in sync with model manager weights filename constant!
 const METADATA_FILENAME = "metadata.json" // must be in sync with model manager metadata filename constant!
 
-var HOST_MODEL_WEIGHTS_PATH = GetOrDefaultEnv("HOST_MODEL_WEIGHTS_PATH", "model/"+WEIGHTS_FILENAME)
-var HOST_MODEL_METADATA_PATH = GetOrDefaultEnv("HOST_MODEL_METADATA_PATH", "model/"+METADATA_FILENAME)
+var HOST_MODEL_WEIGHTS_PATH = GetOrDefaultEnv("HOST_MODEL_WEIGHTS_PATH", "shared/model/"+WEIGHTS_FILENAME)
+var HOST_MODEL_METADATA_PATH = GetOrDefaultEnv("HOST_MODEL_METADATA_PATH", "shared/model/"+METADATA_FILENAME)
 
-var PEERS_MODELS_DIR = GetOrDefaultEnv("PEERS_MODELS_DIR", "peers/")
+var PEERS_MODELS_DIR = GetOrDefaultEnv("PEERS_MODELS_DIR", "shared/peers/")
 
 var DB_DIR = GetOrDefaultEnv("DB_DIR", "database/")

--- a/model_package_core/constants.py
+++ b/model_package_core/constants.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
-PEER_MODEL_PATH = Path('.', 'peers', 'models')
+PEER_MODEL_PATH = Path('.', 'shared', 'peers', 'models')
+
+# must be in sync with networking app filename constants!
 WEIGHT_FILENAME = 'weights.h5'
 METADATA_FILENAME = 'metadata.json'

--- a/model_package_core/pytorch_model/config.py
+++ b/model_package_core/pytorch_model/config.py
@@ -10,12 +10,16 @@ import torch
 DATA_PATH = os.path.join('model_package_core', 'data')
 
 # train data path
-TRAIN_IMAGE_DATA_PATH = os.path.join(DATA_PATH, 'train/MNIST/raw/train-images-idx3-ubyte')
-TRAIN_LABEL_DATA_PATH = os.path.join(DATA_PATH, 'train/MNIST/raw/train-labels-idx1-ubyte')
+TRAIN_IMAGE_DATA_PATH = os.path.join(
+    DATA_PATH, 'train/MNIST/raw/train-images-idx3-ubyte')
+TRAIN_LABEL_DATA_PATH = os.path.join(
+    DATA_PATH, 'train/MNIST/raw/train-labels-idx1-ubyte')
 
 # test data path
-TEST_IMAGE_DATA_PATH = os.path.join(DATA_PATH, 'test/MNIST/raw/t10k-images-idx3-ubyte')
-TEST_LABEL_DATA_PATH = os.path.join(DATA_PATH, 'test/MNIST/raw/t10k-labels-idx1-ubyte')
+TEST_IMAGE_DATA_PATH = os.path.join(
+    DATA_PATH, 'test/MNIST/raw/t10k-images-idx3-ubyte')
+TEST_LABEL_DATA_PATH = os.path.join(
+    DATA_PATH, 'test/MNIST/raw/t10k-labels-idx1-ubyte')
 
 # define the number of samples to use
 NUMBER_OF_TRAIN_SAMPLES = 320
@@ -49,7 +53,7 @@ MIN_DELTA = 0.1
 SAMPLES_TO_PLOT = 5
 
 # define the path to the base output directory
-BASE_OUTPUT = 'model'
+BASE_OUTPUT = 'shared/model'
 os.makedirs(Path(BASE_OUTPUT), exist_ok=True)
 
 # define the path to the output serialized model, metadata and model training plot


### PR DESCRIPTION
Having one shared directory will be easier to mount and provision read/write access once deployed. I think it's also clearer that these files will be interacted with between the model manager and networking app.